### PR TITLE
feat: Populate about.html with detailed text content and styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,36 +16,77 @@
     </nav>
 
     <main>
-        <section id="bio">
-            <h2>About Me</h2>
-            <p>[Please add a brief biography here. You can talk about your journey into cybersecurity and web development, your passions, and what drives you.]</p>
-        </section>
-
-        <section id="skills">
-            <h2>My Skills</h2>
+        <section id="img1-content" class="about-card"> <!-- Added class for styling -->
+            <h1>George Akai</h1> <!-- Main name as H1 -->
+            <p><em>Computer Information Systems & Cybersecurity Student</em></p> <!-- Role/Title -->
+            <p><em>Information Security Assistant @ Chico State</em></p> <!-- Role/Title -->
+            <p><em>Aspiring Cybersecurity Analyst</em></p> <!-- Role/Title -->
+        </section> <!-- End of img1-content -->
+        <section id="img2-background" class="about-card">
+            <h2>Background</h2>
             <ul>
-                <li>[Skill 1 - e.g., Network Security]</li>
-                <li>[Skill 2 - e.g., Python for Cybersecurity]</li>
-                <li>[Skill 3 - e.g., Web Development - HTML, CSS, JavaScript]</li>
-                <li>[Add more skills as relevant]</li>
+                <li>International student from Kenya.</li>
+                <li>I have been pursuing Computer Information Systems for 4 years now.</li>
+                <li>Started getting interested in Cybersecurity 3 years ago.</li>
+                <li>Pursued the Google Cybersecurity Certificate in 2023 and 2024.</li>
+                <li>I participated in the National Cyber League where I got red team security knowledge while also understanding defense strategies.</li>
+                <li>Joined the USR0 cybersecurity club.</li>
+                <li>Work with the Information Security Department on Campus.</li>
             </ul>
-        </section>
-
-        <section id="interests">
-            <h2>Interests & Philosophy</h2>
-            <p>[Share some of your interests outside of work, or your professional philosophy regarding cybersecurity and technology.]</p>
-        </section>
-
-        <section id="gallery">
-            <h2>Gallery</h2>
-            <!-- Images section -->
-            <div class="image-container">
-                <img src="https://github.com/GeorgeAkai/my-portfolio/blob/main/1.png?raw=true" alt="Placeholder for image 1 - [Describe the content or purpose of this image]">
-                <img src="https://github.com/GeorgeAkai/my-portfolio/blob/main/2.png?raw=true" alt="Placeholder for image 2 - [Describe the content or purpose of this image]">
-                <img src="https://github.com/GeorgeAkai/my-portfolio/blob/main/3.png?raw=true" alt="Placeholder for image 3 - [Describe the content or purpose of this image]">
-                <img src="https://github.com/GeorgeAkai/my-portfolio/blob/main/4.png?raw=true" alt="Placeholder for image 4 - [Describe the content or purpose of this image]">
-                <img src="https://github.com/GeorgeAkai/my-portfolio/blob/main/5.png?raw=true" alt="Placeholder for image 5 - [Describe the content or purpose of this image]">
+        </section> <!-- End of img2-background -->
+        <section id="img3-projects" class="about-card">
+            <h2>Projects and Achievements</h2>
+            <p>I have gained some invaluable experience while working with the Information Security Department, spearheading some department’s projects. Below are the projects details and how we achieved our desired outcomes.</p>
+            
+            <div class="project-item"> <!-- Wrapper for a project/achievement -->
+                <h3>User Access Reviews</h3>
+                <p>I spearheaded the 2025 Annual User Access Reviews. The objective was to obtain information from campus MPPs so we could have an updated user access documentation.</p>
             </div>
+
+            <div class="project-item">
+                <h3>Asset Management</h3>
+                <p>Scanned assets like servers and web applications for vulnerability and followed up with the asset owners regarding remediation of the vulnerabilities found.</p>
+            </div>
+
+            <div class="project-item">
+                <h3>Vulnerability Management</h3>
+                <ul> 
+                    <li>Used Qualys vulnerability scanner to scan servers, websites, compliance, and End-Of-Life applications to ensure that every asset is up to date to keep our security posture high.</li>
+                </ul>
+            </div>
+
+            <div class="project-item">
+                <h3>Ticket Management</h3>
+                <p>I managed tickets sent through Team Dynamix to remediate or respond to issues or concerns, and also to facilitate follow-up regarding user access reviews and vulnerability management.</p>
+            </div>
+        </section> <!-- End of img3-projects -->
+        <section id="img4-objectives" class="about-card">
+            <h2>Objectives</h2>
+            <p>This slide outlines the core objectives of my information security experience, emphasizing my expertise in risk assessment, systems security and secure web applications.</p>
+            
+            <div class="objective-item"> <!-- Wrapper for an objective -->
+                <h3>Risk Assessment</h3>
+                <p>Conducting risk assessment is crucial because it outlines the assets that are most at risk, while also balancing business needs with information security needs.</p>
+            </div>
+
+            <div class="objective-item">
+                <h3>Systems Security / Vulnerability Remediation</h3> <!-- Using a more descriptive heading based on context -->
+                <p>Ensuring that identified vulnerabilities in servers and other assets are remediated is central to the security of the organization.</p>
+            </div>
+
+            <div class="objective-item">
+                <h3>Secure Web Development</h3>
+                <p>Building and deploying web application that are secure, and avoid exploitation of the top 10 OWASP for example, SQL injection and Cross-Site Request Forgery (CSRF).</p>
+            </div>
+        </section> <!-- End of img4-objectives -->
+        <section id="img5-thankyou" class="about-card">
+            <h2>THANK YOU!</h2>
+            <ul>
+                <li>George Akai</li>
+                <li>Information Security Assistant</li>
+                <li><a href="https://www.linkedin.com/in/george-akai-91a41022b/" target="_blank" rel="noopener noreferrer">My LinkedIn Page</a></li> <!-- Added target="_blank" for external link -->
+                <li>Chico, CA, USA</li>
+            </ul>
         </section>
     </main>
 </body>

--- a/style.css
+++ b/style.css
@@ -161,3 +161,63 @@ h1 {
         max-width: none; 
     }
 }
+
+/* Styles for new content in about.html */
+.about-card {
+    background-color: #ffffff; /* White background for the card */
+    border: 1px solid #dddddd; /* Light grey border */
+    border-radius: 8px; /* Rounded corners */
+    padding: 20px; /* Padding inside the card */
+    margin-bottom: 20px; /* Space between cards */
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1); /* Subtle shadow for depth */
+    text-align: left; /* Override body text-align: center for card content */
+}
+
+.about-card h1 {
+    font-size: 2em; /* Large for main title */
+    color: #333333;
+    margin-bottom: 0.5em;
+}
+
+.about-card h2 {
+    font-size: 1.5em; /* Medium for section titles */
+    color: #444444;
+    margin-top: 0; /* Remove default top margin if it's the first element */
+    margin-bottom: 0.75em;
+    border-bottom: 1px solid #eeeeee; /* Optional: a light separator line */
+    padding-bottom: 0.25em; /* Space for the separator line */
+}
+
+.about-card h3 {
+    font-size: 1.2em; /* Smaller for sub-section titles */
+    color: #555555;
+    margin-bottom: 0.5em;
+}
+
+.about-card p {
+    font-size: 1em;
+    line-height: 1.6;
+    color: #333333;
+    margin-bottom: 1em; /* Space after paragraphs */
+}
+
+.about-card ul {
+    list-style-position: outside; /* Bullets outside the text flow */
+    padding-left: 20px; /* Indent for the bullets */
+    margin-bottom: 1em; /* Space after lists */
+    color: #333333; /* Ensure list text color matches paragraph text */
+}
+
+.about-card li {
+    margin-bottom: 0.5em; /* Space between list items */
+    line-height: 1.5;
+}
+
+/* Specific styles for intro card titles in #img1-content */
+#img1-content p em { /* Styles the emphasized text in paragraphs */
+    font-style: normal; /* Remove italics if not desired for these titles */
+    font-weight: bold; /* Make them bold */
+    color: #555;
+    display: block; /* Make each title take its own line */
+    margin-bottom: 0.25em;
+}


### PR DESCRIPTION
I've replaced the image-based gallery in about.html with the text content you provided, structured into distinct sections and styled for readability.

Key changes:
- I removed the previous placeholder content and image gallery from about.html.
- I added five new sections to about.html corresponding to the text from Img1 to Img5:
    - Introduction/Titles
    - Background (bulleted list)
    - Projects and Achievements (with sub-sections)
    - Objectives (with sub-sections)
    - THANK YOU! (bulleted list, including a LinkedIn hyperlink)
- I applied CSS styles in style.css for the new ".about-card" sections, including:
    - Card-like appearance (background, border, shadow).
    - Consistent typography for headings, paragraphs, and lists.
    - Specific styling for emphasis on titles in the intro card.
    - Ensured text within cards is left-aligned.

This addresses your request to convert the image-based information into a styled, text-based format on the about page.